### PR TITLE
Make sure get_prep_value can deal with None value

### DIFF
--- a/extypes/django.py
+++ b/extypes/django.py
@@ -86,7 +86,7 @@ class SetField(six.with_metaclass(models.SubfieldBase, models.Field)):
 
         We add self.db_separator on both sides to ease lookups.
         """
-        return self.db_separator.join([''] + list(value) + [''])
+        return self.db_separator.join([''] + list(value or ()) + [''])
 
     def get_display(self, value):
         """Display pretty-printer."""

--- a/tests/django_test_app/migrations/0001_initial.py
+++ b/tests/django_test_app/migrations/0001_initial.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+import extypes.django
+
+
+class Migration(migrations.Migration):
+
+    operations = [
+
+        migrations.CreateModel(
+            "Fridge",
+            [
+                ('id', models.AutoField(serialize=False, auto_created=True, primary_key=True, verbose_name='ID')),
+                ('contents', extypes.django.SetField(
+                    choices=[(b'spam', b'Spam'), (b'bacon', b'Bacon'), (b'eggs', b'Eggs')],
+                    blank=True,
+                    default='', )),
+                ('flags', extypes.django.SetField(
+                    choices=[(b'clean', b'clean'), (b'online', b'online'), (b'open', b'open')],
+                    blank=True,
+                    default='', )),
+            ],
+        ),
+
+    ]

--- a/tests/django_test_app/migrations/0002_alterfield.py
+++ b/tests/django_test_app/migrations/0002_alterfield.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+import extypes.django
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('django_test_app', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='fridge',
+            name='contents',
+            field=extypes.django.SetField(
+                choices=[(b'spam', b'Spam'), (b'bacon', b'Bacon'), (b'eggs', b'Eggs')], blank=True,),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='fridge',
+            name='flags',
+            field=extypes.django.SetField(
+                choices=[(b'clean', b'clean'), (b'online', b'online'), (b'open', b'open')], blank=True),
+            preserve_default=True,
+        ),
+    ]


### PR DESCRIPTION
Django, while computing the project state for its migrations, might end
up selecting None as a possible default, before calling get_db_prep_save
which will call get_prep_value:
https://github.com/django/django/blob/1.7.11/django/db/backends/schema.py#L182-L190

get_db_prep_save should therefore be able to deal with None value.
