### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Links
 
 * Package on PyPI: http://pypi.python.org/pypi/extypes
 * Repository and issues on GitHub: http://github.com/rbarrois/extypes
-* Doc on http://readthedocs.org/docs/extypes/
+* Doc on https://extypes.readthedocs.io/
 
 
 Getting started


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
