### PR TITLE
django: Store `SetField` value in an SQL `text` column instead of `char(n)`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,14 @@
 ChangeLog
 =========
 
+.. _v2.0.0:
+
+2.0.0 (unreleased)
+------------------
+
+*New:*
+
+    - ``extypes.django.SetField`` now stores values with the ``text`` SQL type instead of ``char(n)``. When migrating from a previous version of extypes, this will generate a database migration.
 
 .. _v1.0.1:
 

--- a/extypes/django.py
+++ b/extypes/django.py
@@ -84,7 +84,7 @@ class SetField(models.Field):
 
         Should go for more efficient options, though.
         """
-        return 'char(%d)' % self.max_length
+        return 'text'
 
     def get_prep_value(self, value):
         """Convert to a simple, serializable string.


### PR DESCRIPTION
`SetField` stores values in a `char(n)` column. When a choice is added
or removed from the field, an SQL migration is generated because the
maximum length (to handle all choices) changes. This is annoying.
Using an unlimited column type avoids this issue. The performance of
the `text` and `char(n)` types are similar in PostgreSQL. I don't know
whether it's the same in other databases, but it's unlikely to be an
issue (please don't mark my words).